### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.7.0] - 2021-05-04
 
+- Improved State documentations
+- Improved State debug logs
+
 **Changed**
-- Renamed *Statechart* to *StateMachine* to avoid namespace conflicts
+- Removed redundant *SplitFinal* & *SplitExitFinal* methods from *ISplitState*. Now the *Split* method incorporates all possible cases to simplify implementation
 
 **Fixed**
-- Fixed *ITaskWaitState* bad tests
+- Fixed reference checks for *WaitState*
+- Fixed *StatechartTaskWaitTest* to work also when multiple tests run in parallel
+- Fixed *TaskWaitState* racing condition bug on chained states
+- Fixed bug on *WaitState* that when finished instantaneously would execute state transitions multiple times
 
 ## [0.6.0] - 2020-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2021-05-04
+
+**Changed**
+- Renamed *Statechart* to *StateMachine* to avoid namespace conflicts
+
+**Fixed**
+- Fixed *ITaskWaitState* bad tests
+
 ## [0.6.0] - 2020-09-29
 
 **Changed**

--- a/Runtime/IState.cs
+++ b/Runtime/IState.cs
@@ -176,21 +176,6 @@ namespace GameLovers.Statechart
 		/// <see cref="ISplitState"/> is completed.
 		/// It does not execute the <see cref="IFinalState"/> of it's nested states when this
 		/// <see cref="ISplitState"/> is completed.
-		/// </remarks>
-		ITransition Split(Action<IStateFactory> setup1, Action<IStateFactory> setup2);
-		
-		/// <inheritdoc cref="Split"/>
-		/// <remarks>
-		/// It executes the <see cref="IStateExit.OnExit"/> of the current active states when this
-		/// <see cref="ISplitState"/> is completed.
-		/// If the given <paramref name="executeFinal1"/> or <paramref name="executeFinal2"/> or is true,
-		/// then the internal <see cref="IFinalState"/> will be executed when leaving the nested state from an event
-		/// or from a <see cref="ILeaveState"/> from one of the inner states.
-		/// </remarks>
-		ITransition SplitFinal(Action<IStateFactory> setup1, Action<IStateFactory> setup2, bool executeFinal1, bool executeFinal2);
-		
-		/// <inheritdoc cref="Split"/>
-		/// <remarks>
 		/// If the given <paramref name="executeExit1"/> or <paramref name="executeExit2"/> or is true,
 		/// then the internal current active <see cref="IStateExit.OnExit"/> will be executed when leaving the nested state
 		/// from completion of this <see cref="ISplitState"/>.
@@ -198,9 +183,9 @@ namespace GameLovers.Statechart
 		/// then the internal <see cref="IFinalState"/> will be executed when leaving the nested state from an event
 		/// or from a <see cref="ILeaveState"/> from one of the inner states.
 		/// </remarks>
-		ITransition SplitExitFinal(Action<IStateFactory> setup1, Action<IStateFactory> setup2,
-		                           bool executeExit1, bool executeExit2,
-		                           bool executeFinal1, bool executeFinal2);
+		ITransition Split(Action<IStateFactory> setup1, Action<IStateFactory> setup2,
+		                  bool executeExit1 = true, bool executeExit2 = true,
+		                  bool executeFinal1 = true, bool executeFinal2 = true);
 	}
 
 	/// <summary>

--- a/Runtime/IStateFactory.cs
+++ b/Runtime/IStateFactory.cs
@@ -27,7 +27,6 @@ namespace GameLovers.Statechart
 		ITaskWaitState TaskWait(string name);
 		/// <inheritdoc cref="ISplitState"/>
 		ISplitState Split(string name);
-
 		/// <inheritdoc cref="ILeaveState"/>
 		ILeaveState Leave(string name);
 	}

--- a/Runtime/Internal/NestState.cs
+++ b/Runtime/Internal/NestState.cs
@@ -106,7 +106,7 @@ namespace GameLovers.Statechart.Internal
 		}
 
 		/// <inheritdoc />
-		public ITransition Nest(Action<IStateFactory> setup, bool executeExit = true, bool executeFinal = false)
+		public ITransition Nest(Action<IStateFactory> setup, bool executeExit = true, bool executeFinal = true)
 		{
 			if (_transition != null)
 			{

--- a/Runtime/Internal/SplitState.cs
+++ b/Runtime/Internal/SplitState.cs
@@ -143,21 +143,8 @@ namespace GameLovers.Statechart.Internal
 		}
 
 		/// <inheritdoc />
-		public ITransition Split(Action<IStateFactory> setup1, Action<IStateFactory> setup2)
-		{
-			return SplitExitFinal(setup1, setup2, true, true, false, false);
-		}
-
-		/// <inheritdoc />
-		public ITransition SplitFinal(Action<IStateFactory> setup1, Action<IStateFactory> setup2, bool executeFinal1,
-		                              bool executeFinal2)
-		{
-			return SplitExitFinal(setup1, setup2, true, true, executeFinal1, executeFinal2);
-		}
-
-		/// <inheritdoc />
-		public ITransition SplitExitFinal(Action<IStateFactory> setup1, Action<IStateFactory> setup2, bool executeExit1, 
-		                                  bool executeExit2, bool executeFinal1, bool executeFinal2)
+		public ITransition Split(Action<IStateFactory> setup1, Action<IStateFactory> setup2, bool executeExit1 = true, 
+		                                  bool executeExit2 = true, bool executeFinal1 = true, bool executeFinal2 = true)
 		{
 			if (_transition != null)
 			{

--- a/Runtime/Internal/SplitState.cs
+++ b/Runtime/Internal/SplitState.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEngine;
 
 // ReSharper disable CheckNamespace
 

--- a/Runtime/Internal/StateFactory.cs
+++ b/Runtime/Internal/StateFactory.cs
@@ -8,21 +8,46 @@ namespace GameLovers.Statechart.Internal
 	/// <inheritdoc />
 	internal interface IStateFactoryInternal : IStateFactory
 	{
+		/// <summary>
+		/// The Layer that this <see cref="IStateFactory"/> is building upon
+		/// </summary>
 		uint RegionLayer { get; }
+		/// <summary>
+		/// The current <see cref="InitialState"/> that this <see cref="IStateFactory"/> is building upon
+		/// </summary>
 		InitialState InitialState { get; }
+		/// <summary>
+		/// The current <see cref="FinalState"/> that this <see cref="IStateFactory"/> is building upon
+		/// </summary>
 		FinalState FinalState { get; }
+		/// <summary>
+		/// The current list of states that this <see cref="IStateFactory"/> is building upon
+		/// </summary>
 		IList<IStateInternal> States { get; }
+		/// <summary>
+		/// The <see cref="StateFactoryData"/> that this <see cref="IStateFactory"/> is building upon
+		/// </summary>
 		StateFactoryData Data { get; }
+		
+		/// <summary>
+		/// Adds the given list of <paramref name="states"/> to this <see cref="IStateFactory"/> to building upon
+		/// </summary>
+		/// <param name="states"></param>
 		void Add(IList<IStateInternal> states);
 	}
 
 	/// <inheritdoc />
 	internal class StateFactory : IStateFactoryInternal
 	{
+		/// <inheritdoc />
 		public uint RegionLayer { get; private set; }
+		/// <inheritdoc />
 		public InitialState InitialState { get; private set; }
+		/// <inheritdoc />
 		public FinalState FinalState { get; private set; }
+		/// <inheritdoc />
 		public IList<IStateInternal> States { get; private set; }
+		/// <inheritdoc />
 		public StateFactoryData Data { get; private set; }
 
 		private StateFactory()
@@ -40,9 +65,9 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public void Add(IList<IStateInternal> states)
 		{
-			foreach (var state in states)
+			for (var i = 0; i < states.Count; i++)
 			{
-				States.Add(state);
+				States.Add(states[i]);
 			}
 		}
 

--- a/Runtime/Internal/StateInternal.cs
+++ b/Runtime/Internal/StateInternal.cs
@@ -26,21 +26,21 @@ namespace GameLovers.Statechart.Internal
 		string CreationStackTrace { get; }
 		
 		/// <summary>
-		/// Triggers the given <paramref name="statechartEvent"/> as input to the <see cref="IStateMachine"/> and returns
+		/// Triggers the given <paramref name="statechartEvent"/> as input to the <see cref="IStatechart"/> and returns
 		/// the processed <see cref="IStateInternal"/> as an output
 		/// </summary>
 		IStateInternal Trigger(IStatechartEvent statechartEvent);
 		/// <summary>
-		/// Marks the initial moment of this state as the new current state in the <see cref="IStateMachine"/>
+		/// Marks the initial moment of this state as the new current state in the <see cref="IStatechart"/>
 		/// </summary>
 		void Enter();
 		/// <summary>
-		/// Marks the final moment of this state as the current state in the <see cref="IStateMachine"/>
+		/// Marks the final moment of this state as the current state in the <see cref="IStatechart"/>
 		/// </summary>
 		void Exit();
 		/// <summary>
 		/// Validates this state to any potential bad setup schemes. Relevant to debug purposes.
-		/// It requires the <see cref="IStateMachine"/> to run at runtime.
+		/// It requires the <see cref="IStatechart"/> to run at runtime.
 		/// </summary>
 		void Validate();
 	}
@@ -63,7 +63,7 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public string CreationStackTrace { get; }
 
-		protected bool IsStateLogsEnabled => LogsEnabled || _stateFactory.Data.StateMachine.LogsEnabled;
+		protected bool IsStateLogsEnabled => LogsEnabled || _stateFactory.Data.Statechart.LogsEnabled;
 
 		protected StateInternal(string name, IStateFactoryInternal stateFactory)
 		{
@@ -86,7 +86,7 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"'{statechartEvent?.Name}' does not trigger any transition in state '{Name}'");
+					Debug.Log($"({GetType().UnderlyingSystemType.Name}) - '{statechartEvent?.Name}' : ## STOP ## '{Name}'");
 				}
 				
 				return null;
@@ -98,8 +98,8 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"'{statechartEvent?.Name}' event triggers the transition in state'{Name}' to" +
-					          $"itself because it's of type {GetType().UnderlyingSystemType.Name}");
+					Debug.Log($"({GetType().UnderlyingSystemType.Name}) - '{statechartEvent?.Name}' : " +
+					          $"'{Name}' -> '{Name}' because => {GetType().UnderlyingSystemType.Name}");
 				}
 				
 				return nextState;
@@ -158,7 +158,7 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"Entering '{state.Name}'");
+					Debug.Log($"({state.GetType().UnderlyingSystemType.Name}) - Entering '{state.Name}'");
 				}
 				state.Enter();
 			}
@@ -174,7 +174,7 @@ namespace GameLovers.Statechart.Internal
 			{
 				if(IsStateLogsEnabled)
 				{
-					Debug.LogFormat($"Exiting '{Name}'");
+					Debug.LogFormat($"({GetType().UnderlyingSystemType.Name}) - Exiting '{Name}'");
 				}
 				Exit();
 			}
@@ -190,9 +190,9 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					var targetState = transition.TargetState?.Name ?? "only invokes OnTransition() without moving to new state";
+					var targetState = transition.TargetState?.Name ?? "only invokes OnTransition()";
 					
-					Debug.Log($"'{eventName}' event triggers the transition '{Name}' -> '{targetState}'");
+					Debug.Log($"({GetType().UnderlyingSystemType.Name}) - '{eventName}' : '{Name}' -> '{targetState}'");
 				}
 				
 				transition.TriggerTransition();

--- a/Runtime/Internal/StateInternal.cs
+++ b/Runtime/Internal/StateInternal.cs
@@ -63,7 +63,7 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public string CreationStackTrace { get; }
 
-		protected bool IsStateLogsEnabled => LogsEnabled || _stateFactory.Data.Statechart.LogsEnabled;
+		protected bool IsStateLogsEnabled => LogsEnabled || _stateFactory.Data.StateMachine.LogsEnabled;
 
 		protected StateInternal(string name, IStateFactoryInternal stateFactory)
 		{

--- a/Runtime/Internal/StatechartUtils.cs
+++ b/Runtime/Internal/StatechartUtils.cs
@@ -2,8 +2,14 @@
 
 namespace GameLovers.Statechart.Internal
 {
+	/// <summary>
+	/// Helper class for the statechart to work properly
+	/// </summary>
 	internal static class StatechartUtils
 	{
+		/// <summary>
+		/// Cleans ups the given <paramref name="stackTrace"/> of unnecessary string data
+		/// </summary>
 		public static string RemoveGarbageFromStackTrace(string stackTrace)
 		{
 			var lineIdx = stackTrace.IndexOf('\n') + 1;

--- a/Runtime/Internal/TaskWaitState.cs
+++ b/Runtime/Internal/TaskWaitState.cs
@@ -137,16 +137,16 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"'{eventName}' event triggers the task wait method '{_taskAwaitAction.Method.Name}'" +
-					          $"from the object {_taskAwaitAction.Target} in the state {Name}");
+					Debug.Log($"'{eventName}' : '{_taskAwaitAction.Target}.{_taskAwaitAction.Method.Name}()' => '{Name}'");
 				}
-				
+
+				await Task.Delay(1);
 				await _taskAwaitAction();
 			}
 			catch (Exception e)
 			{
-				throw new Exception($"Exception in the state '{Name}', when calling the task wait action {_taskAwaitAction.Method.Name}" +
-				                    $"from the object {_taskAwaitAction.Target}.\n" + CreationStackTrace, e);
+				throw new Exception($"Exception in the state '{Name}', when calling the task wait action " +
+				                    $"'{_taskAwaitAction.Target}.{_taskAwaitAction.Method.Name}()'.\n" + CreationStackTrace, e);
 			}
 
 			_completed = true;

--- a/Runtime/Internal/TaskWaitState.cs
+++ b/Runtime/Internal/TaskWaitState.cs
@@ -42,6 +42,8 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public override void Exit()
 		{
+			_completed = true;
+			
 			for(int i = 0; i < _onExit.Count; i++)
 			{
 				_onExit[i]?.Invoke();
@@ -149,11 +151,12 @@ namespace GameLovers.Statechart.Internal
 				                    $"'{_taskAwaitAction.Target}.{_taskAwaitAction.Method.Name}()'.\n" + CreationStackTrace, e);
 			}
 
-			_completed = true;
-
 			// Checks if the state didn't exited from an outsource trigger (Nested State) before the Task was completed
-			if (_executionCount - 1 == currentExecution)
+
+			if (!_completed && _executionCount - 1 == currentExecution)
 			{
+				_completed = true;
+				
 				_stateFactory.Data.StateChartMoveNextCall(null);
 			}
 		}

--- a/Runtime/Internal/TaskWaitState.cs
+++ b/Runtime/Internal/TaskWaitState.cs
@@ -137,7 +137,7 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"'{eventName}' : '{_taskAwaitAction.Target}.{_taskAwaitAction.Method.Name}()' => '{Name}'");
+					Debug.Log($"TaskWait - '{eventName}' : '{_taskAwaitAction.Target}.{_taskAwaitAction.Method.Name}()' => '{Name}'");
 				}
 
 				await Task.Delay(1);

--- a/Runtime/Internal/TaskWaitState.cs
+++ b/Runtime/Internal/TaskWaitState.cs
@@ -142,7 +142,7 @@ namespace GameLovers.Statechart.Internal
 					Debug.Log($"TaskWait - '{eventName}' : '{_taskAwaitAction.Target}.{_taskAwaitAction.Method.Name}()' => '{Name}'");
 				}
 
-				await Task.Delay(1);
+				await Task.Yield();
 				await _taskAwaitAction();
 			}
 			catch (Exception e)
@@ -152,7 +152,6 @@ namespace GameLovers.Statechart.Internal
 			}
 
 			// Checks if the state didn't exited from an outsource trigger (Nested State) before the Task was completed
-
 			if (!_completed && _executionCount - 1 == currentExecution)
 			{
 				_completed = true;

--- a/Runtime/Internal/Transition.cs
+++ b/Runtime/Internal/Transition.cs
@@ -8,11 +8,28 @@ namespace GameLovers.Statechart.Internal
 	/// <inheritdoc />
 	internal interface ITransitionInternal : ITransitionCondition
 	{
+		/// <summary>
+		/// The current target state of this transition
+		/// </summary>
 		IStateInternal TargetState { get; }
+		/// <summary>
+		/// True if this transition has a condition to check, false otherwise 
+		/// </summary>
 		bool HasCondition { get; }
+		/// <summary>
+		/// Debug stack trace string
+		/// </summary>
 		string CreationStackTrace { get; }
 		
+		/// <summary>
+		/// Checks the defined transition condition.
+		/// Returns true if the condition is met, false otherwise
+		/// </summary>
+		/// <returns></returns>
 		bool CheckCondition();
+		/// <summary>
+		/// Trigger the defined transition
+		/// </summary>
 		void TriggerTransition();
 	}
 
@@ -34,7 +51,7 @@ namespace GameLovers.Statechart.Internal
 		{
 			var ret = true;
 
-			for(int i = 0; i < _condition.Count; i++)
+			for(var i = 0; i < _condition.Count; i++)
 			{
 				ret = ret && _condition[i].Invoke();
 			}
@@ -45,7 +62,7 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public void TriggerTransition()
 		{
-			for(int i = 0; i < _onTransition.Count; i++)
+			for(var i = 0; i < _onTransition.Count; i++)
 			{
 				_onTransition[i]?.Invoke();
 			}

--- a/Runtime/Internal/TransitionState.cs
+++ b/Runtime/Internal/TransitionState.cs
@@ -19,7 +19,7 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public override void Enter()
 		{
-			for(int i = 0; i < _onEnter.Count; i++)
+			for(var i = 0; i < _onEnter.Count; i++)
 			{
 				_onEnter[i]?.Invoke();
 			}
@@ -28,7 +28,7 @@ namespace GameLovers.Statechart.Internal
 		/// <inheritdoc />
 		public override void Exit()
 		{
-			for(int i = 0; i < _onExit.Count; i++)
+			for(var i = 0; i < _onExit.Count; i++)
 			{
 				_onExit[i]?.Invoke();
 			}

--- a/Runtime/Internal/WaitActivity.cs
+++ b/Runtime/Internal/WaitActivity.cs
@@ -8,9 +8,22 @@ namespace GameLovers.Statechart.Internal
 	/// <inheritdoc />
 	internal interface IWaitActivityInternal : IWaitActivity
 	{
+		/// <summary>
+		/// The unique value id that defines this awaitable <see cref="IWaitActivity"/>
+		/// </summary>
 		uint Id { get; }
+		/// <summary>
+		/// The amount of times this activity has been awaited in the <see cref="WaitState"/>.
+		/// Used to guarantee that inner awaitable calls don't bypass parent awaitable calls on a chain of <see cref="WaitState"/>
+		/// </summary>
 		uint ExecutionCount { get; set; }
+		/// <summary>
+		/// Returns true if this activity has been marked as completed, false otherwise
+		/// </summary>
 		bool IsCompleted { get; }
+		/// <summary>
+		/// Resets the state of this activity to it's initial values
+		/// </summary>
 		void Reset();
 	}
 

--- a/Runtime/Internal/WaitActivity.cs
+++ b/Runtime/Internal/WaitActivity.cs
@@ -95,6 +95,11 @@ namespace GameLovers.Statechart.Internal
 				}
 			}
 
+			if (IsCompleted)
+			{
+				return;
+			}
+
 			IsCompleted = true;
 
 			if (_innerOnComplete != null)

--- a/Runtime/Internal/WaitState.cs
+++ b/Runtime/Internal/WaitState.cs
@@ -137,7 +137,7 @@ namespace GameLovers.Statechart.Internal
 			return _waitingActivity.IsCompleted && _waitingActivity.ExecutionCount == _executionCount - 1 ? _transition : null;
 		}
 
-		private async void InnerWait(string eventName)
+		private void InnerWait(string eventName)
 		{
 			_waitingActivity.ExecutionCount = _executionCount;
 			_executionCount++;
@@ -146,16 +146,15 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"Wait - '{eventName}' : '{_waitAction.Target}.{_waitAction.Method.Name}()' => '{Name}'");
+					Debug.Log($"'{eventName}' event triggers the wait method '{_waitAction.Method.Name}'" +
+					          $"from the object {_waitAction.Target} in the state {Name}");
 				}
-
-				await Task.Delay(1);
 				_waitAction(_waitingActivity);
 			}
 			catch(Exception e)
 			{
-				throw new Exception($"Exception in the state '{Name}', when calling the task wait action " +
-				                    $"'{_waitAction.Target}.{_waitAction.Method.Name}()'.\n" + CreationStackTrace, e);
+				throw new Exception($"Exception in the state '{Name}', when calling the wait action {_waitAction.Method.Name}" +
+				                    $"from the object {_waitAction.Target}.\n" + CreationStackTrace, e);
 			}
 		}
 	}

--- a/Runtime/Internal/WaitState.cs
+++ b/Runtime/Internal/WaitState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GameLovers.Statechart;
 using UnityEngine;
 
@@ -136,7 +137,7 @@ namespace GameLovers.Statechart.Internal
 			return _waitingActivity.IsCompleted && _waitingActivity.ExecutionCount == _executionCount - 1 ? _transition : null;
 		}
 
-		private void InnerWait(string eventName)
+		private async void InnerWait(string eventName)
 		{
 			_waitingActivity.ExecutionCount = _executionCount;
 			_executionCount++;
@@ -145,15 +146,16 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"'{eventName}' event triggers the wait method '{_waitAction.Method.Name}'" +
-					          $"from the object {_waitAction.Target} in the state {Name}");
+					Debug.Log($"'{eventName}' : '{_waitAction.Target}.{_waitAction.Method.Name}()' => '{Name}'");
 				}
+
+				await Task.Delay(1);
 				_waitAction(_waitingActivity);
 			}
 			catch(Exception e)
 			{
-				throw new Exception($"Exception in the state '{Name}', when calling the wait action {_waitAction.Method.Name}" +
-				                    $"from the object {_waitAction.Target}.\n" + CreationStackTrace, e);
+				throw new Exception($"Exception in the state '{Name}', when calling the task wait action " +
+				                    $"'{_waitAction.Target}.{_waitAction.Method.Name}()'.\n" + CreationStackTrace, e);
 			}
 		}
 	}

--- a/Runtime/Internal/WaitState.cs
+++ b/Runtime/Internal/WaitState.cs
@@ -146,7 +146,7 @@ namespace GameLovers.Statechart.Internal
 			{
 				if (IsStateLogsEnabled)
 				{
-					Debug.Log($"'{eventName}' : '{_waitAction.Target}.{_waitAction.Method.Name}()' => '{Name}'");
+					Debug.Log($"Wait - '{eventName}' : '{_waitAction.Target}.{_waitAction.Method.Name}()' => '{Name}'");
 				}
 
 				await Task.Delay(1);

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -64,21 +64,16 @@ namespace GameLovers.Statechart
 
 		public StateMachine(Action<IStateFactory> setup)
 		{
-			var stateFactory = new StateFactory(0, new StateFactoryData { StateMachine = this, StateChartMoveNextCall = MoveNext });
+			var data = new StateFactoryData { StateMachine = this, StateChartMoveNextCall = MoveNext };
+			var stateFactory = new StateFactory(0, data);
 
 			setup(stateFactory);
 
 			_stateFactory = stateFactory;
-
-			if (_stateFactory.InitialState == null)
-			{
-				throw new MissingMemberException("State chart doesn't have initial state");
-			}
-
-			_currentState = _stateFactory.InitialState;
+			_currentState = _stateFactory.InitialState ?? throw new MissingMemberException("State chart doesn't have initial state");
 
 #if UNITY_EDITOR || DEBUG
-			for(int i = 0; i < _stateFactory.States.Count; i++)
+			for(var i = 0; i < _stateFactory.States.Count; i++)
 			{
 				_stateFactory.States[i].Validate();
 			}

--- a/Tests/Editor/StatechartLeaveTest.cs
+++ b/Tests/Editor/StatechartLeaveTest.cs
@@ -396,7 +396,7 @@ namespace GameLoversEditor.Statechart.Tests
 			initial.OnExit(() => _caller.InitialOnExitCall(1));
 
 			split.OnEnter(() => _caller.StateOnEnterCall(1));
-			split.SplitFinal(setup1, setup2, executeFinal, executeFinal)
+			split.Split(setup1, setup2, true, true,executeFinal, executeFinal)
 			     .OnTransition(() => _caller.OnTransitionCall(3)).Target(final);
 			split.Event(_event2).OnTransition(() => _caller.OnTransitionCall(4)).Target(final);
 			split.OnExit(() => _caller.StateOnExitCall(1));

--- a/Tests/Editor/StatechartSplitTest.cs
+++ b/Tests/Editor/StatechartSplitTest.cs
@@ -486,20 +486,8 @@ namespace GameLoversEditor.Statechart.Tests
 			initial.OnExit(() => _caller.InitialOnExitCall(1));
 
 			split.OnEnter(() => _caller.StateOnEnterCall(1));
-			if (!executeExit)
-			{
-				split.SplitExitFinal(setup1, setup2, false, false, executeFinal, executeFinal)
-				     .OnTransition(() => _caller.OnTransitionCall(3)).Target(final);
-			}
-			else if (executeFinal)
-			{
-				split.SplitFinal(setup1, setup2, true, true)
-				     .OnTransition(() => _caller.OnTransitionCall(3)).Target(final);
-			}
-			else
-			{
-				split.Split(setup1, setup2).OnTransition(() => _caller.OnTransitionCall(3)).Target(final);
-			}
+			split.Split(setup1, setup2, executeExit, executeExit, executeFinal, executeFinal)
+			     .OnTransition(() => _caller.OnTransitionCall(3)).Target(final);
 			split.Event(eventTrigger).OnTransition(() => _caller.OnTransitionCall(4)).Target(final);
 			split.OnExit(() => _caller.StateOnExitCall(1));
 

--- a/Tests/Editor/StatechartStateTest.cs
+++ b/Tests/Editor/StatechartStateTest.cs
@@ -94,7 +94,7 @@ namespace GameLoversEditor.Statechart.Tests
 		}
 
 		[Test]
-		public void PauseRunStatechart()
+		public void PauseRunStateMachine()
 		{
 			var statechart = new StateMachine(SetupEventState);
 
@@ -112,7 +112,7 @@ namespace GameLoversEditor.Statechart.Tests
 		}
 
 		[Test]
-		public void ResetRunStatechart()
+		public void ResetRunStateMachine()
 		{
 			var statechart = new StateMachine(SetupEventState);
 

--- a/Tests/Editor/StatechartTaskWaitTest.cs
+++ b/Tests/Editor/StatechartTaskWaitTest.cs
@@ -57,9 +57,9 @@ namespace GameLoversEditor.Statechart.Tests
 			_caller.DidNotReceive().FinalOnEnterCall(0);
 
 			_blocker = false;
-
+			
 			yield return YieldCoroutine();
-				
+			
 			_caller.Received().OnTransitionCall(1);
 			_caller.DidNotReceive().OnTransitionCall(2);
 			_caller.Received().StateOnExitCall(0);
@@ -86,7 +86,7 @@ namespace GameLoversEditor.Statechart.Tests
 			_blocker = false;
 			
 			yield return YieldCoroutine();
-
+				
 			_caller.Received().OnTransitionCall(1);
 			_caller.Received().OnTransitionCall(2);
 			_caller.Received().StateOnExitCall(0);
@@ -187,12 +187,12 @@ namespace GameLoversEditor.Statechart.Tests
 		{
 			while (_blocker)
 			{
-				await Task.Delay(1);
+				await Task.Yield();
 			}
 
 			_done = true;
 		}
-
+		
 		private IEnumerator YieldCoroutine()
 		{
 			while (!_done)

--- a/Tests/Editor/StatechartTaskWaitTest.cs
+++ b/Tests/Editor/StatechartTaskWaitTest.cs
@@ -31,12 +31,14 @@ namespace GameLoversEditor.Statechart.Tests
 
 		private IMockCaller _caller;
 		private bool _blocker;
+		private bool _done;
 		
 		[SetUp]
 		public void Init()
 		{
 			_caller = Substitute.For<IMockCaller>();
 			_blocker = true;
+			_done = false;
 		}
 
 		[UnityTest]
@@ -187,14 +189,18 @@ namespace GameLoversEditor.Statechart.Tests
 			{
 				await Task.Delay(1);
 			}
+
+			_done = true;
 		}
 
 		private IEnumerator YieldCoroutine()
 		{
-			for (int i = 0; i < 5; i++)
+			while (!_done)
 			{
 				yield return null;
 			}
+			
+			yield return null;
 		}
 
 		private void SetupTaskWaitState(IStateFactory factory, Func<Task> waitAction)

--- a/Tests/Editor/StatechartWaitTest.cs
+++ b/Tests/Editor/StatechartWaitTest.cs
@@ -50,6 +50,7 @@ namespace GameLoversEditor.Statechart.Tests
 			_caller.DidNotReceive().StateOnExitCall(0);
 			_caller.DidNotReceive().FinalOnEnterCall(0);
 
+			await Task.Yield(); // To avoid race conditions with the activity creation
 			activity.Complete();
 
 			_caller.Received().OnTransitionCall(1);
@@ -116,6 +117,7 @@ namespace GameLoversEditor.Statechart.Tests
 			_caller.DidNotReceive().FinalOnEnterCall(0);
 			_caller.Received().FinalOnEnterCall(1);
 			
+			await Task.Yield(); // To avoid race conditions with the activity creation
 			activity.Complete();
 			
 			_caller.DidNotReceive().OnTransitionCall(1);
@@ -156,6 +158,7 @@ namespace GameLoversEditor.Statechart.Tests
 			_caller.DidNotReceive().StateOnExitCall(0);
 			_caller.DidNotReceive().FinalOnEnterCall(0);
 
+			await Task.Yield(); // To avoid race conditions with the activity creation
 			activitySplit = activity.Split();
 			activity.Complete();
 
@@ -189,6 +192,7 @@ namespace GameLoversEditor.Statechart.Tests
 			_caller.DidNotReceive().StateOnExitCall(0);
 			_caller.DidNotReceive().FinalOnEnterCall(0);
 
+			await Task.Yield(); // To avoid race conditions with the activity creation
 			activity.Split();
 			activity.Complete();
 

--- a/Tests/Editor/StatechartWaitTest.cs
+++ b/Tests/Editor/StatechartWaitTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using GameLovers.Statechart;
 using NSubstitute;
 using NUnit.Framework;
@@ -34,7 +35,7 @@ namespace GameLoversEditor.Statechart.Tests
 		}
 
 		[Test]
-		public void BasicSetup()
+		public async void BasicSetup()
 		{
 			IWaitActivity activity = null;
 
@@ -83,7 +84,7 @@ namespace GameLoversEditor.Statechart.Tests
 		}
 
 		[Test]
-		public void NestState_OuterEventTriggerAndActivityComplete_NoTransition()
+		public async void NestState_OuterEventTriggerAndActivityComplete_NoTransition()
 		{
 			IWaitActivity activity = null;
 			
@@ -141,7 +142,7 @@ namespace GameLoversEditor.Statechart.Tests
 		}
 
 		[Test]
-		public void SplitActivity_CompleteBoth()
+		public async void SplitActivity_CompleteBoth()
 		{
 			IWaitActivity activity = null;
 			IWaitActivity activitySplit = null;
@@ -176,7 +177,7 @@ namespace GameLoversEditor.Statechart.Tests
 		}
 
 		[Test]
-		public void SplitActivity_CompleteOnlyOneActivity()
+		public async void SplitActivity_CompleteOnlyOneActivity()
 		{
 			IWaitActivity activity = null;
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "com.gamelovers.statechart",
   "displayName": "Statechart",
-  "version": "0.6.0",
-  "unity": "2019.3",
+  "version": "0.7.0",
+  "unity": "2020.3",
   "description": "This package allows the use of Statecharts (Hierarchichal State Machine) within an Unity project.\n\nThe primary feature of Statecharts is that states can be organized in a hierarchy.\nA Statecharts is a state machine where each state in the state machine may define its own subordinate state machines, called substates.\nThose states can again define substates.\n\nFor more information: https://statecharts.github.io/what-is-a-statechart.html",
   "type": "library",
   "hideInEditor": false


### PR DESCRIPTION
- Improved State documentations
- Improved State debug logs

**Changed**
- Removed redundant *SplitFinal* & *SplitExitFinal* methods from *ISplitState*. Now the *Split* method incorporates all possible cases to simplify implementation

**Fixed**
- Fixed reference checks for *WaitState*
- Fixed *StatechartTaskWaitTest* to work also when multiple tests run in parallel
- Fixed *TaskWaitState* racing condition bug on chained states
- Fixed bug on *WaitState* that when finished instantaneously would execute state transitions multiple times